### PR TITLE
Improve undigit perfomance, can specify base

### DIFF
--- a/src/Digits.jl
+++ b/src/Digits.jl
@@ -19,8 +19,12 @@ export
   digitroot
 
 
-function undigit(l::Array{Int,1})
-  return foldr((a,b)->b*10+a,0,l)
+function undigit(l::Vector{Int}, base::Int = 10)
+  acc = 0
+  for (i, digit) in enumerate(l)
+    acc += digit * base ^ (i-1)
+  end
+  acc::Int
 end
 
 undigit(n::Int) = n


### PR DESCRIPTION
Perfomance gain of 2.5 by using an explicit for loop
Not using functional constructs (which julia is currently not very good at optimizing) in undigit gives large perfomance gains, especially when using numbers with many digits.
I tested two implementations:

```
function undigit2(ds::Vector{Int}, base::Int = 10)
    acc = 0
    for digit in reverse(ds)
        acc = base * acc + digit
    end
    acc::Int
end

function undigit3(ds::Vector{Int}, base::Int = 10)
    acc = 0
    for (i, digit) in enumerate(ds)
        acc += digit * base ^ (i-1)
    end
    acc::Int
end
```

The last implementation was more perfomant when profiling:

```
@time for i in 1000000:10000000
    @assert undigit2(digits(i)) == i
end
   3.021 seconds      (18000 k allocations: 2197 MB, 7.94% gc time)

@time for i in 1000000:10000000
    @assert undigit3(digits(i)) == i
end
   2.583 seconds      (18000 k allocations: 1236 MB, 6.28% gc time)
```

Both were more performant than the current implementation:

```
@time for i in 1000000:
    @assert undigit(digits(i)) == i
end
   6.885 seconds      (99680 k allocations: 2482 MB, 3.53% gc time)
```
