### PR TITLE
Fixes for julia v0.7 and v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,17 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
+
 notifications:
   email: false
 
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Digits"); Pkg.test("Digits"; coverage=true)'
-  
+#script: # the default script is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Digits"); Pkg.test("Digits"; coverage=true)';
+
 after_success:
-- julia -e 'cd(Pkg.dir("Digits")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Digits")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+#  - julia -e 'if VERSION >= v"0.7.0-" using Pkg end; cd(Pkg.dir("Digits")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ Computes the digital root of n. That is the iterative sum of the digits until th
 
 
 ### Notes
-- Most functions accept an array of digits aswell as an integer as input.
+- Most functions accept an array of digits as well as an integer as input.
 - For most of the array methods there exists an inplace operation.
 - This package should also work for negative integers, but this can become tricky. Take a closer look at the digit representation of negative integers. `digits(-135)` -> `[-5, -3, -1]`.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat
+julia 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,43 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
     - master
     - /release-.*/
 
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-  - ps: (new-object net.webclient).DownloadFile($env:JULIA_URL, "C:\projects\julia-binary.exe")
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-  - C:\projects\julia\bin\julia-debug -e "versioninfo(); Pkg.clone(\"Digits\"); Pkg.build(\"Digits\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia-debug -e "Pkg.test(\"Digits\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/Digits.jl
+++ b/src/Digits.jl
@@ -1,7 +1,6 @@
 module Digits
 
 import Base:
-  contains,
   startswith,
   endswith
 
@@ -41,7 +40,7 @@ function digithist(l::Array{Int,1})
   h = zeros(Int,10)
   for i in 1:length(l)
     d = abs(l[i])
-    h[d+1] .= h[d+1] + 1
+    h[d+1] = h[d+1] + 1
   end
   return h
 end
@@ -50,7 +49,7 @@ function digithist(n::Integer)
   h = zeros(Int,10)
   for i=1:ndigits(n)
     d = abs(rem(n,10))
-    h[d+1] .= h[d+1] + 1
+    h[d+1] = h[d+1] + 1
     n = div(n,10)
   end
   return h

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,5 @@
 using Digits
-@static if VERSION < v"0.7-dev"
-    @eval using Base.Test
-else
-    @eval using Test
-end
+using Test
 
 # test data
 n = 1234567890


### PR DESCRIPTION
This makes this repository work again with Julia v1.0. Although some tests on computers with 32bit architectures fail.